### PR TITLE
Add `azure-ai/examples/deploy-nvidia-parakeet-asr`

### DIFF
--- a/examples/azure-ai/deploy-nvidia-parakeet-asr/azure-notebook.ipynb
+++ b/examples/azure-ai/deploy-nvidia-parakeet-asr/azure-notebook.ipynb
@@ -1,0 +1,924 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "aa3b3fb3-ccce-4654-8a3a-02bb4016eeaf",
+   "metadata": {},
+   "source": [
+    "# Deploy NVIDIA Parakeet for Automatic Speech Recognition (ASR) on Azure AI"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "975fe589-9800-4124-a3be-d9f618da61a4",
+   "metadata": {},
+   "source": [
+    "This example showcases how to deploy NVIDIA Parakeet for Automatic Speech Recognition (ASR) from the Hugging Face Collection in Azure AI Foundry Hub as an Azure ML Managed Online Endpoint, powered by Hugging Face's Inference container on top of NVIDIA NeMo. Additionally, this example also showcases how to run inference with cURL, requests, OpenAI Python SDK, and even how to locally run a Gradio application for audio transcription from both recordings and files.\n",
+    "\n",
+    "TL;DR NVIDIA NeMo is a scalable generative AI framework built for researchers and developers working on Large Language Models, Multimodal, and Speech AI (Automatic Speech Recognition and Text-to-Speech). NVIDIA NeMo Parakeet ASR Models attain strong speech recognition accuracy while being efficient for inference. Azure AI Foundry provides a unified platform for enterprise AI operations, model builders, and application development. Azure Machine Learning is a cloud service for accelerating and managing the machine learning (ML) project lifecycle."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d723dca0-9016-4b7c-a21b-ff01f75ea440",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef145992-e426-491d-b218-87ecd9d06d65",
+   "metadata": {},
+   "source": [
+    "This example will specifically deploy [`nvidia/parakeet-tdt-0.6b-v2`](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2) from the Hugging Face Hub (or see it on [AzureML](https://ml.azure.com/models/nvidia-parakeet-tdt-0.6b-v2/version/4/catalog/registry/HuggingFace) or on [Azure AI Foundry](https://ai.azure.com/explore/models/nvidia-parakeet-tdt-0.6b-v2/version/4/registry/HuggingFace)) as an Azure ML Managed Online Endpoint on Azure AI Foundry Hub.\n",
+    "\n",
+    "`nvidia/parakeet-tdt-0.6b-v2` is a 600-million-parameter automatic speech recognition (ASR) model designed for high-quality English transcription, featuring support for punctuation, capitalization, and accurate timestamp prediction.\n",
+    "\n",
+    "This XL variant of the FastConformer architecture integrates the TDT decoder and is trained with full attention, enabling efficient transcription of audio segments up to 24 minutes in a single pass. The model achieves an RTFx of 3380 on the HF-Open-ASR leaderboard with a batch size of 128. Note: RTFx Performance may vary depending on dataset audio duration and batch size.\n",
+    "\n",
+    "* Accurate word-level timestamp predictions\n",
+    "* Automatic punctuation and capitalization\n",
+    "* Robust performance on spoken numbers, and song lyrics transcription\n",
+    "\n",
+    "![NVIDIA Parakeet on the Hugging Face Hub](./nvidia-parakeet-hub.png)\n",
+    "\n",
+    "![NVIDIA Parakeet on Azure ML](./nvidia-parakeet-azure-ml.png)\n",
+    "\n",
+    "![NVIDIA Parakeet on Azure AI Foundry](./nvidia-parakeet-azure-ai.png)\n",
+    "\n",
+    "For more information, make sure to check [their model card on the Hugging Face Hub](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2/blob/main/README.md) and the [NVIDIA NeMo Documentation](https://docs.nvidia.com/nemo-framework/user-guide/latest/nemotoolkit/asr/models.html).\n",
+    "\n",
+    "> [!NOTE]\n",
+    "> Note that you can select any Automatic Speech Recognition (ASR) model available on the Hugging Face Hub with the tag `NeMo` and the \"Deploy to AzureML\" option enabled, or directly select any of the ASR models available on either Azure ML or Azure AI Foundry Hub Model Catalog under the \"HuggingFace\" collection (note that for Azure AI Foundry the Hugging Face Collection will only be available for Hub-based projects), but only the NVIDIA Parakeet models are powered by NVIDIA NeMo, the rest of those rely on the Hugging Face Inference Toolkit."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "763a3a3a-aae1-43be-a925-0a4e1f5493a3",
+   "metadata": {},
+   "source": [
+    "## Pre-requisites"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "037b80f6-10c2-4f23-b035-9e74a669c7d9",
+   "metadata": {},
+   "source": [
+    "To run the following example, you will need to comply with the following pre-requisites, alternatively, you can also read more about those in the [Azure Machine Learning Tutorial: Create resources you need to get started](https://learn.microsoft.com/en-us/azure/machine-learning/quickstart-create-resources?view=azureml-api-2)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d202cf55-91bc-4f45-b97d-845c3ad8488a",
+   "metadata": {},
+   "source": [
+    "### Azure Account"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b96373e3-8e3b-49dc-a423-719d7139f5eb",
+   "metadata": {},
+   "source": [
+    "A Microsoft Azure account with an active subscription. If you don't have a Microsoft Azure account, you can now [create one for free](https://azure.microsoft.com/en-us/pricing/purchase-options/azure-account), including 200 USD worth of credits to use within the next 30 days after the account creation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a35caf6b-512f-4b82-894c-f3508b5857be",
+   "metadata": {},
+   "source": [
+    "### Azure CLI"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e1c8888-537f-47e6-b4b3-2aaccdefe9e6",
+   "metadata": {},
+   "source": [
+    "The Azure CLI (`az`) installed on the instance that you're running this example on, see [the installation steps](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest), and follow the steps of the preferred method based on your instance. Then log in into your subscription as follows:\n",
+    "\n",
+    "```bash\n",
+    "az login\n",
+    "```\n",
+    "\n",
+    "More information at [Sign in with Azure CLI - Login and Authentication](https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli?view=azure-cli-latest)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8d148e7-5bd8-469c-9c1e-4fc55a1ac1ed",
+   "metadata": {},
+   "source": [
+    "### Azure CLI extension for Azure ML"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2fb90286-5162-4574-aeca-c338172b2668",
+   "metadata": {},
+   "source": [
+    "Besides the Azure CLI (`az`), you also need to install the Azure ML CLI extension (`az ml`) which will be used to create the Azure ML and Azure AI Foundry required resources.\n",
+    "\n",
+    "First you will need to list the current extensions and remove any `ml`-related extension before installing the latest one i.e., v2.\n",
+    "\n",
+    "```bash\n",
+    "az extension list\n",
+    "az extension remove --name azure-cli-ml\n",
+    "az extension remove --name ml\n",
+    "```\n",
+    "\n",
+    "Then you can install the `az ml` v2 extension as follows:\n",
+    "\n",
+    "```bash\n",
+    "az extension add --name ml\n",
+    "```\n",
+    "\n",
+    "More information at [Azure Machine Learning (ML) - Install and setup the CLI (v2)](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-configure-cli?view=azureml-api-2&tabs=public)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dbdbfef2-3161-4678-bd07-16fa29c7bbec",
+   "metadata": {},
+   "source": [
+    "### Azure Resource Group"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b27c159f-93b9-4ba0-b6ed-9eb4a07729b7",
+   "metadata": {},
+   "source": [
+    "An Azure Resource Group under the one you will create the Azure AI Foundry Hub-based project (note it will create an Azure AI Foundry resource as an Azure ML Workspace, but not the other way around, meaning that the Azure AI Foundry Hub will be listed as an Azure ML workspace, but leveraging the Azure AI Foundry capabilities for Gen AI), and the rest of the required resources. If you don't have one, you can create it as follow:\n",
+    "\n",
+    "```bash\n",
+    "az group create --name huggingface-azure-rg --location eastus\n",
+    "```\n",
+    "\n",
+    "Then, you can ensure that the resource group was created successfully by e.g. listing all the available resource groups that you have access to on your subscription:\n",
+    "\n",
+    "```bash\n",
+    "az group list --output table\n",
+    "```\n",
+    "\n",
+    "More information at [Manage Azure resource groups by using Azure CLI](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resource-groups-cli).\n",
+    "\n",
+    "> [!NOTE]\n",
+    "> You can also create the Azure Resource Group [via the Azure Portal](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resource-groups-portal), or [via the Azure Resource Management Python SDK](https://learn.microsoft.com/en-us/azure/developer/python/sdk/examples/azure-sdk-example-resource-group?tabs=bash) (requires it to be installed as `pip install azure-mgmt-resource` in advance)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b45eaa4d-9942-46ec-985f-1748443ed9ac",
+   "metadata": {},
+   "source": [
+    "### Azure AI Foundry Hub-based project"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0b2c56d-9197-42e0-b723-63811c7e25f0",
+   "metadata": {},
+   "source": [
+    "An Azure AI Foundry Hub under the subscription and resource group aforementioned. If you don't have one, you can create it as follows:\n",
+    "\n",
+    "```bash\n",
+    "az ml workspace create \\\n",
+    "    --kind hub \\\n",
+    "    --name huggingface-azure-hub \\\n",
+    "    --resource-group huggingface-azure-rg \\\n",
+    "    --location eastus\n",
+    "```\n",
+    "\n",
+    "> [!NOTE]\n",
+    "> Note that the main difference with an standard Azure ML Workspace is that the Azure AI Foundry Hub command requires you to specify the `--kind hub`, removing it would create a standard Azure ML Workspace instead, so you wouldn't benefit from the features that the Azure AI Foundry brings. But, when you create an Azure AI Foundry Hub, you can still benefit from all the features that Azure ML brings, since the Azure AI Foundry Hub will still rely on Azure ML, but not the other way around.\n",
+    "\n",
+    "Then, you can ensure that the workspace was created successfully by e.g. listing all the available workspaces that you have access to on your subscription:\n",
+    "\n",
+    "```bash\n",
+    "az ml workspace list --filtered-kinds hub --query \"[].{Name:name, Kind:kind}\" --resource-group huggingface-azure-rg --output table\n",
+    "```\n",
+    "\n",
+    "> [!WARNING]\n",
+    "> The `--filtered-kinds` argument has been recently included as of [Azure ML CLI 2.37.0](https://learn.microsoft.com/en-us/azure/machine-learning/azure-machine-learning-release-notes-cli-v2?view=azureml-api-2#azure-machine-learning-cli-v2-v-2370), meaning that you may need to upgrade `az ml` as `az extension update --name ml`.\n",
+    "\n",
+    "Once the Azure AI Foundry Hub is created, you need to create an Azure AI Foundry Project linked to that Hub, to do so you first need to obtain the Azure AI Foundry Hub ID of the recently created Hub as follows (replace the resource names with yours):\n",
+    "\n",
+    "```bash\n",
+    "az ml workspace show \\\n",
+    "    --name huggingface-azure-hub \\\n",
+    "    --resource-group huggingface-azure-rg \\\n",
+    "    --query \"id\" \\\n",
+    "    -o tsv\n",
+    "```\n",
+    "\n",
+    "That command will provide the ID as follows `/subscriptions/<SUBSCRIPTION_ID>/resourceGroups/<RESOURCE_GROUP>/providers/Microsoft.MachineLearningServices/workspaces/huggingface-azure-hub`, meaning that you can also format it manually yourself with the appropriate replacements. Then you need to run the following command to create the Azure AI Foundry Project for that Hub as:\n",
+    "\n",
+    "```bash\n",
+    "az ml workspace create \\\n",
+    "    --kind project \\\n",
+    "    --hub-id $(az ml workspace show --name huggingface-azure-hub --resource-group huggingface-azure-rg --query \"id\" -o tsv) \\\n",
+    "    --name huggingface-azure-project \\\n",
+    "    --resource-group huggingface-azure-rg \\\n",
+    "    --location eastus\n",
+    "```\n",
+    "\n",
+    "Finally, you can verify that it was correctly created with the following command:\n",
+    "\n",
+    "```bash\n",
+    "az ml workspace list --filtered-kinds project --query \"[].{Name:name, Kind:kind}\" --resource-group huggingface-azure-rg --output table\n",
+    "```\n",
+    "\n",
+    "More information at [How to create and manage an Azure AI Foundry Hub](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/create-azure-ai-resource?tabs=portal) and at [How to create a Hub using the Azure CLI](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/create-hub-project-sdk?tabs=azurecli).\n",
+    "\n",
+    "> [!NOTE]\n",
+    "> You can also create the Azure AI Foundry Hub [via the Azure Portal](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/create-secure-ai-hub), or [via the Azure ML Python SDK](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/create-hub-project-sdk?tabs=python), among other options listed in [Manage AI Hub Resources](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/ai-resources)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d439f949-f482-4ed9-9d66-0d6ae93d5173",
+   "metadata": {},
+   "source": [
+    "## Setup and installation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8eade47-ccfa-4add-a10f-933e2190f169",
+   "metadata": {},
+   "source": [
+    "In this example, the [Azure Machine Learning SDK for Python](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/ml/azure-ai-ml) will be used to create the endpoint and the deployment, as well as to invoke the deployed API. Along with it, you will also need to install `azure-identity` to authenticate with your Azure credentials via Python."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3979198-34e9-48f1-99f1-2c49b447a60d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install azure-ai-ml azure-identity --upgrade --quiet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "026d4738-831e-4de0-a1df-dcacd05db5b8",
+   "metadata": {},
+   "source": [
+    "More information at [Azure Machine Learning SDK for Python](https://learn.microsoft.com/en-us/python/api/overview/azure/ai-ml-readme?view=azure-python)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2351ec9b-3dbc-4227-82b6-0c71d47a6358",
+   "metadata": {},
+   "source": [
+    "Then, for convenience setting the following environment variables is recommended as those will be used along the example for the Azure ML Client, so make sure to update and set those values accordingly as per your Microsoft Azure account and resources."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "666920ea-31eb-4019-9d4d-f1e7d8fd2447",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%env LOCATION eastus\n",
+    "%env SUBSCRIPTION_ID <YOUR_SUBSCRIPTION_ID>\n",
+    "%env RESOURCE_GROUP <YOUR_RESOURCE_GROUP>\n",
+    "%env AI_FOUNDRY_HUB_PROJECT <YOUR_AI_FOUNDRY_HUB_PROJECT>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b466d3a-e959-4db2-8be3-4d8e14e20e77",
+   "metadata": {},
+   "source": [
+    "Finally, you also need to define both the endpoint and deployment names, as those will be used throughout the example too:\n",
+    "\n",
+    "> [!NOTE]\n",
+    "> Note that endpoint names must to be globally unique per region i.e., even if you don't have any endpoint named that way running under your subscription, if the name is reserved by another Azure customer, then you won't be able to use the same name. Adding a timestamp or a custom identifier is recommended to prevent running into HTTP 400 validation issues when trying to deploy an endpoint with an already locked / reserved name. Also the endpoint name must be between 3 and 32 characters long."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "535de43e-f532-44ce-a848-f1cff5bca5c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from uuid import uuid4\n",
+    "\n",
+    "os.environ[\"ENDPOINT_NAME\"] = f\"nvidia-parakeet-{str(uuid4())[:8]}\"\n",
+    "os.environ[\"DEPLOYMENT_NAME\"] = f\"nvidia-parakeet-{str(uuid4())[:8]}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5f75a14-8246-4ceb-9ab2-03d6d232cc7f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!echo $ENDPOINT_NAME\n",
+    "!echo $DEPLOYMENT_NAME"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "786e1c5f-4815-43b7-9227-f9b7c333329d",
+   "metadata": {},
+   "source": [
+    "## Authenticate to Azure ML"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "026488f0-3a44-433e-b84f-76588678ed77",
+   "metadata": {},
+   "source": [
+    "Initially, you need to authenticate into the Azure AI Foundry Hub via Azure ML with the Azure ML Python SDK, which will be later used to deploy `nvidia/parakeet-tdt-0.6b-v2` as an Azure ML Managed Online Endpoint in your Azure AI Foundry Hub.\n",
+    "\n",
+    "> [!NOTE]\n",
+    "> On standard Azure ML deployments you'd need to create the `MLClient` using the Azure ML Workspace as the `workspace_name` whereas for Azure AI Foundry, you need to provide the Azure AI Foundry Hub name as the `workspace_name` instead, and that will deploy the endpoint under the Azure AI Foundry too."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cbe4b31f-34b2-4209-ba99-f3ee99ce2c9f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from azure.ai.ml import MLClient\n",
+    "from azure.identity import DefaultAzureCredential\n",
+    "\n",
+    "client = MLClient(\n",
+    "    credential=DefaultAzureCredential(),\n",
+    "    subscription_id=os.getenv(\"SUBSCRIPTION_ID\"),\n",
+    "    resource_group_name=os.getenv(\"RESOURCE_GROUP\"),\n",
+    "    workspace_name=os.getenv(\"AI_FOUNDRY_HUB_PROJECT\"),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2498c42-2e9a-4d0f-9c51-2d9775a92eaf",
+   "metadata": {},
+   "source": [
+    "## Create and Deploy Azure AI Endpoint"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0adfbfd-ca52-4d8c-992b-8d2b72b497d3",
+   "metadata": {},
+   "source": [
+    "Before creating the Managed Online Endpoint, you need to build the model URI, which is formatted as it follows `azureml://registries/<REGISTRY_NAME>/models/<MODEL_ID>/labels/latest` (even if the URI contains `azureml` it's the same as in Azure AI Foundry, since the model catalog is shared), that means that the `REGISTRY_NAME` should be set to \"HuggingFace\" as you intend to deploy a model from the Hugging Face Collection, and the `MODEL_ID` won't be the Hugging Face Hub ID, but rather the ID with hyphen replacements for both backslash (/) and underscores (_) with hyphens (-), and then into lower case, as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c5a77a0-3ce3-418d-b161-757a2b09232b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_id = \"nvidia/parakeet-tdt-0.6b-v2\"\n",
+    "\n",
+    "model_uri = f\"azureml://registries/HuggingFace/models/{model_id.replace('/', '-').replace('_', '-').lower()}/labels/latest\"\n",
+    "model_uri"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a432367e-e39a-409e-845d-9ea38406359d",
+   "metadata": {},
+   "source": [
+    "Note that you will need to verify in advance that the URI is valid, and that the given Hugging Face Hub Model ID exists on Azure, since Hugging Face is publishing those models into their collection, meaning that some models may be available on the Hugging Face Hub but not yet on the Azure Model Catalog (you can request adding a model following the guide [Request a model addition](https://huggingface.co/docs/microsoft-azure/guides/request-model-addition)).\n",
+    "\n",
+    "Alternatively, you can use the following snippet to verify if a model is available on the Azure Model Catalog programmatically:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d01768a4-c860-497e-bdea-1e9528b09469",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "\n",
+    "response = requests.get(f\"https://generate-azureml-urls.azurewebsites.net/api/generate?modelId={model_id}\")\n",
+    "if response.status_code != 200:\n",
+    "    print(\"[{response.status_code=}] {model_id=} not available on the Hugging Face Collection in Azure ML Model Catalog\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb3cb25a-c411-47b2-8c60-bf62de39feb5",
+   "metadata": {},
+   "source": [
+    "Then you can create the Managed Online Endpoint specifying its name (note that the name must be unique per entire region, not only within a single subscription, resource group, workspace, etc., so it's a nice practice to add some sort of unique name to it in case multi-region deployments are intended) via the [ManagedOnlineEndpoint Python class](https://learn.microsoft.com/en-us/python/api/azure-ai-ml/azure.ai.ml.entities.managedonlineendpoint?view=azure-python).\n",
+    "\n",
+    "Also note that by default the `ManagedOnlineEndpoint` will use the `key` authentication method, meaning that there will be a primary and secondary key that should be sent within the Authentication headers as a Bearer token; but also the `aml_token` authentication method can be used, read more about it at [Authenticate clients for online endpoints](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-authenticate-online-endpoint).\n",
+    "\n",
+    "The deployment, created via the [ManagedOnlineDeployment Python class](https://learn.microsoft.com/en-us/python/api/azure-ai-ml/azure.ai.ml.entities.managedonlinedeployment?view=azure-python), will define the actual model deployment that will be exposed via the previously created endpoint. The `ManagedOnlineDeployment` will expect: the `model` i.e., the previously created URI `azureml://registries/HuggingFace/models/nvidia-parakeet-tdt-0.6b-v2/labels/latest`, the `endpoint_name`, and the instance requirements being the `instance_type` and the `instance_count`.\n",
+    "\n",
+    "Every model in the Hugging Face Collection is powered by an efficient inference backend, and each of those can run on a wide variety of instance types (as listed in [Supported Hardware](https://huggingface.co/docs/microsoft-azure/azure-ai/supported-hardware)); in this case, a NVIDIA H100 GPU will be used i.e., `Standard_NC40ads_H100_v5`.\n",
+    "\n",
+    "> [!WARNING]\n",
+    "> Since for some models and inference engines you need to run those on a GPU-accelerated instance, you may need to request a quota increase for some of the supported instances as per the model you want to deploy. Also, keep into consideration that each model comes with a list of all the supported instances, being the recommended one for each tier the lower instance in terms of available VRAM. Read more about quota increase requests for Azure ML at [Manage and increase quotas and limits for resources with Azure Machine Learning](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-manage-quotas?view=azureml-api-2)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43e8cd42-5ea4-44a7-b998-dbd1cbf9c6be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from azure.ai.ml.entities import ManagedOnlineEndpoint, ManagedOnlineDeployment\n",
+    "\n",
+    "endpoint = ManagedOnlineEndpoint(name=os.getenv(\"ENDPOINT_NAME\"))\n",
+    "\n",
+    "deployment = ManagedOnlineDeployment(\n",
+    "    name=os.getenv(\"DEPLOYMENT_NAME\"),\n",
+    "    endpoint_name=os.getenv(\"ENDPOINT_NAME\"),\n",
+    "    model=model_uri,\n",
+    "    instance_type=\"Standard_NC40ads_H100_v5\",\n",
+    "    instance_count=1,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33d81645-0a8b-4388-b250-13564ea86b6e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.begin_create_or_update(endpoint).wait()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "646eb1ae-1497-4303-9631-e5bab3022301",
+   "metadata": {},
+   "source": [
+    "![Azure AI Endpoint from Azure ML Studio](./azure-ml-endpoint.png)\n",
+    "\n",
+    "![Azure AI Endpoint from Azure AI Foundry](./azure-ai-endpoint.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5261e54-4564-42f2-927f-9ca4d6f49726",
+   "metadata": {},
+   "source": [
+    "> [!NOTE]\n",
+    "> In Azure AI Foundry the endpoint will only be listed within the \"My assets -> Models + endpoints\" tab once the deployment is created, not before as in Azure ML where the endpoint is shown even if it doesn't contain any active or in-progress deployments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a1e82cd-3bd4-4ecf-a5bf-6423b37733ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.online_deployments.begin_create_or_update(deployment).wait()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b135caa-a700-4e5c-8f2b-48b9a709c8b2",
+   "metadata": {},
+   "source": [
+    "![Azure AI Deployment from Azure ML Studio](./azure-ml-deployment.png)\n",
+    "\n",
+    "![Azure AI Deployment from Azure AI Foundry](./azure-ai-deployment.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb416947-fdb0-4eeb-90d7-c27630b50da4",
+   "metadata": {},
+   "source": [
+    "> [!NOTE]\n",
+    "> Note that whilst the Azure AI Endpoint creation is relatively fast, the deployment will take longer since it needs to allocate the resources on Azure so expect it to take ~10-15 minutes, but it could as well take longer depending on the instance provisioning and availability."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d848bd46-ff36-4bb4-822e-b8f2f2ed8b0c",
+   "metadata": {},
+   "source": [
+    "Once deployed, via either the Azure AI Foundry or the Azure ML Studio you'll be able to inspect the endpoint details, the real-time logs, how to consume the endpoint, and even use the, still on preview, [monitoring feature](https://learn.microsoft.com/en-us/azure/machine-learning/concept-model-monitoring?view=azureml-api-2).\n",
+    "\n",
+    "Find more information about it at [Azure ML Managed Online Endpoints](https://learn.microsoft.com/en-us/azure/machine-learning/concept-endpoints-online?view=azureml-api-2#managed-online-endpoints)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "614189ee-a224-404a-bd5a-2347d7404c5f",
+   "metadata": {},
+   "source": [
+    "## Send requests to the Azure AI Endpoint"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ee9b306-7331-4fc3-bb65-d7e2134e7d5e",
+   "metadata": {},
+   "source": [
+    "Finally, now that the Azure AI Endpoint is deployed, you can send requests to it. In this case, since the task of the model is `automatic-speech-recognition` and since it expects a multi-part request to be sent along the audio file, the `invoke` method cannot be used since it only supports JSON payloads.\n",
+    "\n",
+    "This being said, you can still send requests to it programmatically via `requests`, via the OpenAI SDK for Python or with cURL, to the `/api/v1/audio/transcriptions` route which is the OpenAI-compatible route for the Transcriptions API.\n",
+    "\n",
+    "> [!WARNING]\n",
+    "> Support for Hugging Face models via [`azure-ai-inference` Python SDK](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/ai/azure-ai-inference) is still a work in progress, but that will be included soon and set as the recommended inference method, stay tuned!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16580ae3-624f-4ff0-89d2-b6405f03be88",
+   "metadata": {},
+   "source": [
+    "To send the requests then we need both the `primary_key` and the `scoring_uri`, which can be retrieved via the Azure ML Python SDK as it follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58d0a7d0-b9e2-4a35-bd49-21431f2c443a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api_key = client.online_endpoints.get_keys(os.getenv(\"ENDPOINT_NAME\")).primary_key\n",
+    "api_url = client.online_endpoints.get(os.getenv(\"ENDPOINT_NAME\")).scoring_uri"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c2eee3e-2f76-462b-af92-a947cf598b9b",
+   "metadata": {},
+   "source": [
+    "Additionally, since you will need a sample audio file to run the inference over, you will need to download an audio file as e.g. the following, which is the audio file showcased within the `nvidia/parakeet-tdt-0.6b-v2` model card:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bdf057ae-b0ef-4c1c-8ae0-5eb54d527346",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!wget https://dldata-public.s3.us-east-2.amazonaws.com/2086-149220-0033.wav"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75fa9838-c1da-4fd9-a1fd-05fc70785064",
+   "metadata": {},
+   "source": [
+    "### Python `requests`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6d51dbc-64d8-4ce3-9577-ff80d5f2089e",
+   "metadata": {},
+   "source": [
+    "As the deployed Azure AI Endpoint for ASR expects a multi-part request, you need to send separately the files, in this case being the audio files, and the data, being the request parameters such as e.g. the model name or the temperature, among others. To do so, you first need to read the audio file into an `io.BytesIO` object, and then prepare the requests with the necessary headers for both the authentication and the `azureml-model-deployment` set to point to the actual Azure AI Deployment, and send the HTTP POST with both the file and the data as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a6da557-d1e4-4a03-81a4-c3344472bc8b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from io import BytesIO\n",
+    "import requests\n",
+    "\n",
+    "audio_file = BytesIO(open(\"2086-149220-0033.wav\", \"rb\").read())\n",
+    "audio_file.name = \"2086-149220-0033.wav\"\n",
+    "\n",
+    "response = requests.post(\n",
+    "    api_url,\n",
+    "    headers={\n",
+    "        \"Authorization\": f\"Bearer {api_key}\",\n",
+    "        \"azureml-model-deployment\": os.getenv(\"DEPLOYMENT_NAME\"),\n",
+    "    },\n",
+    "    files={\"file\": (audio_file.name, audio_file, \"audio/wav\")},\n",
+    "    data={\"model\": model_id},\n",
+    ")\n",
+    "print(response.json())\n",
+    "# {'text': \"Well, I don't wish to see it any more, observed Phebe, turning away her eyes. It is certainly very like the old portrait.\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6d6e4b5-9f99-49cd-9b2a-09d8bb1e69bd",
+   "metadata": {},
+   "source": [
+    "### OpenAI Python SDK"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d470af7-0fee-4e20-97a4-e64a7e8f4071",
+   "metadata": {},
+   "source": [
+    "As the exposed scoring URI is an OpenAI-compatible route i.e., `/api/v1/audio/transcriptions`, you can leverage the OpenAI Python SDK to send requests to the deployed Azure AI Endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37703050-df09-4825-9328-b591ef53632d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install openai --upgrade --quiet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98c2bfad-a1e8-483f-888b-2793097fb01a",
+   "metadata": {},
+   "source": [
+    "To use the OpenAI Python SDK with Azure ML Managed Online Endpoints, you need to update the `api_url` value defined above, since the default `scoring_uri` comes with the full route, whereas the OpenAI SDK expects the route up until the `v1` included, meaning that the `/audio/transcriptions` should be removed before instantiating the client."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7dddbe29-8498-46d5-bc71-6903cf8a36ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api_url = client.online_endpoints.get(os.getenv(\"ENDPOINT_NAME\")).scoring_uri.replace(\"/audio/transcriptions\", \"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29679b34-3982-4ed6-92a5-6136d596310d",
+   "metadata": {},
+   "source": [
+    "> [!NOTE]\n",
+    "> Alternatively, you can also build the API URL manually as it follows, since the URIs are globally unique per region, meaning that there will only be one endpoint named the same way within the same region:\n",
+    "> ```python\n",
+    "> api_url = f\"https://{os.getenv('ENDPOINT_NAME')}.{os.getenv('LOCATION')}.inference.ml.azure.com/api/v1\"\n",
+    "> ```\n",
+    "> Or just retrieve it from either the Azure AI Foundry or the Azure ML Studio."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb1e2ff6-c135-43c2-b466-49c9054030ef",
+   "metadata": {},
+   "source": [
+    "Then you can use the OpenAI Python SDK normally, making sure to include the extra header `azureml-model-deployment` header that contains the Azure AI / ML Deployment name.\n",
+    "\n",
+    "Via the OpenAI Python SDK it can either be set within each call to `chat.completions.create` via the `extra_headers` parameter as commented below, or via the `default_headers` parameter when instantiating the `OpenAI` client (which is the recommended approach since the header needs to be present on each request, so setting it just once is preferred)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "97aa18d5-04f5-4876-820b-d416e91e588a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from openai import OpenAI\n",
+    "\n",
+    "openai_client = OpenAI(\n",
+    "    base_url=api_url,\n",
+    "    api_key=api_key,\n",
+    "    default_headers={\"azureml-model-deployment\": os.getenv(\"DEPLOYMENT_NAME\")},\n",
+    ")\n",
+    "\n",
+    "transcription = openai_client.audio.transcriptions.create(\n",
+    "    model=model_id,\n",
+    "    file=open(\"2086-149220-0033.wav\", \"rb\"),\n",
+    "    response_format=\"json\",\n",
+    ")\n",
+    "print(transcription.text)\n",
+    "# Well, I don't wish to see it any more, observed Phebe, turning away her eyes. It is certainly very like the old portrait."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19a2463a-b968-4f35-8553-98c3e507123d",
+   "metadata": {},
+   "source": [
+    "### cURL"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84f92a80-0001-445f-9e07-c00643721a79",
+   "metadata": {},
+   "source": [
+    "Alternatively, you can also just use `cURL` to send requests to the deployed endpoint, with the `api_url` and `api_key` values programmatically retrieved in the OpenAI snippet and now set as environment variables so that `cURL` can use those, as it follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ccea9fb-3749-4e9b-ac3b-51304d57fee3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ[\"API_URL\"] = api_url\n",
+    "os.environ[\"API_KEY\"] = api_key"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d88e895-61fc-4b56-831a-76c8ca9ece39",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!curl -sS $API_URL/audio/transcriptions \\\n",
+    "    -H \"Authorization: Bearer $API_KEY\" \\\n",
+    "    -H \"azureml-model-deployment: $DEPLOYMENT_NAME\" \\\n",
+    "    -H \"Content-Type: multipart/form-data\" \\\n",
+    "    -F file=@2086-149220-0033.wav \\\n",
+    "    -F model=nvidia/parakeet-tdt-0.6b-v2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "464c9356-be10-4ec8-aa48-195245c2de82",
+   "metadata": {},
+   "source": [
+    "You can also just go to the Azure AI Endpoint in either the Azure AI Foundry under \"My assets -> Models + endpoints\" or in the Azure ML Studio via \"Endpoints\", and retrieve both the scoring URI and the API Key values, as well as the Azure AI / ML Deployment name for the given model, and then send the request as follows after replacing the values:\n",
+    "\n",
+    "```bash\n",
+    "curl -sS <API_URL> \\\n",
+    "    -H \"Authorization: Bearer <PRIMARY_KEY>\" \\\n",
+    "    -H \"azureml-model-deployment: $DEPLOYMENT_NAME\" \\\n",
+    "    -H \"Content-Type: multipart/form-data\" \\\n",
+    "    -F file=@2086-149220-0033.wav \\\n",
+    "    -F model=nvidia/parakeet-tdt-0.6b-v2 | jq\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5940423f-22fb-4c5a-98ef-852634d1e2bf",
+   "metadata": {},
+   "source": [
+    "### Gradio"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1da0c194-dd5b-4ea6-b984-566aea47f8d2",
+   "metadata": {},
+   "source": [
+    "[Gradio](https://www.gradio.app/) is the fastest way to demo your machine learning model with a friendly web interface so that anyone can use it. You can also leverage the OpenAI Python SDK to build a simple automatic-speech-recognition i.e., speech to text demo that you can use within the Jupyter Notebook cell where you are running it.\n",
+    "\n",
+    "> [!NOTE]\n",
+    "> Alternatively, the Gradio demo connected to your Azure ML Managed Online Endpoint as an Azure Container App as described in [Tutorial: Build and deploy from source code to Azure Container Apps](https://learn.microsoft.com/en-us/azure/container-apps/tutorial-deploy-from-code?tabs=python). If you'd like us to show you how to do it for Gradio in particular, feel free to [open an issue requesting it](https://github.com/huggingface/Microsoft-Azure/issues/new)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a5ae688-cdb5-4751-aa8f-ca2178668185",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install gradio --upgrade --quiet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05a8101a-bd37-476d-81c9-8585ca20d5df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import gradio as gr\n",
+    "from openai import OpenAI\n",
+    "\n",
+    "openai_client = OpenAI(\n",
+    "    base_url=os.getenv(\"API_URL\"),\n",
+    "    api_key=os.getenv(\"API_KEY\"),\n",
+    "    default_headers={\"azureml-model-deployment\": os.getenv(\"DEPLOYMENT_NAME\")}\n",
+    ")\n",
+    "\n",
+    "def transcribe(audio: Path, temperature: float = 1.0) -> str:\n",
+    "    return openai_client.audio.transcriptions.create(\n",
+    "        model=model_id,\n",
+    "        file=open(audio, \"rb\"),\n",
+    "        temperature=temperature,\n",
+    "        response_format=\"text\",\n",
+    "    )\n",
+    "\n",
+    "demo = gr.Interface(\n",
+    "    fn=transcribe,\n",
+    "    inputs=[\n",
+    "        # https://www.gradio.app/docs/gradio/audio\n",
+    "        gr.Audio(type=\"filepath\", streaming=False, label=\"Upload or Record Audio\"),\n",
+    "        gr.Slider(0, 1, value=0.0, step=0.1, label=\"Temperature\")\n",
+    "    ],\n",
+    "    outputs=gr.Textbox(label=\"Transcribed Text\"),\n",
+    "    title=\"NVIDIA Parakeet on Azure AI\",\n",
+    "    description=\"Upload or record audio and get the transcribed text using NVIDIA Parakeet on Azure AI via the OpenAI's Transcription API.\",\n",
+    ")\n",
+    "\n",
+    "demo.launch()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77b5549e-345f-4b21-88c2-e1019a3f30b4",
+   "metadata": {},
+   "source": [
+    "![Gradio Chat Interface with Azure ML Endpoint](./azure-ml-gradio.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1bf20842-e691-4f8c-949c-fb3fc1038336",
+   "metadata": {},
+   "source": [
+    "## Release resources"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c475ca0a-cea2-45bc-b93c-3824fc73cf6d",
+   "metadata": {},
+   "source": [
+    "Once you are done using the Azure AI Endpoint / Deployment, you can delete the resources as it follows, meaning that you will stop paying for the instance on which the model is running and all the attached costs will be stopped."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9cd52337-cce6-431c-b036-fb91d0a894ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.online_endpoints.begin_delete(name=os.getenv(\"ENDPOINT_NAME\")).result()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aaa2816f-bae1-48e4-8b4d-753b34a149ac",
+   "metadata": {},
+   "source": [
+    "## Conclusion"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35d01c0b-44fc-40b6-bfc7-7ba8dcb1432f",
+   "metadata": {},
+   "source": [
+    "Throughout this example you learnt how to create and configure your Azure account for Azure ML and Azure AI Foundry, how to then create a Managed Online Endpoint running an open model for Automatic Speech Recognition (ASR) from the Hugging Face Collection in the Azure AI Foundry Hub / Azure ML Model Catalog, how to send inference requests to it afterwards with different alternatives, how to build a simple Gradio chat interface around it, and finally, how to stop and release the resources.\n",
+    "\n",
+    "If you have any doubt, issue or question about this example, feel free to [open an issue](https://github.com/huggingface/Microsoft-Azure/issues/new) and we'll do our best to help!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/azure-ai/deploy-nvidia-parakeet-asr/azure-notebook.ipynb
+++ b/examples/azure-ai/deploy-nvidia-parakeet-asr/azure-notebook.ipynb
@@ -13,7 +13,7 @@
    "id": "975fe589-9800-4124-a3be-d9f618da61a4",
    "metadata": {},
    "source": [
-    "This example showcases how to deploy NVIDIA Parakeet for Automatic Speech Recognition (ASR) from the Hugging Face Collection in Azure AI Foundry Hub as an Azure ML Managed Online Endpoint, powered by Hugging Face's Inference container on top of NVIDIA NeMo. Additionally, this example also showcases how to run inference with cURL, requests, OpenAI Python SDK, and even how to locally run a Gradio application for audio transcription from both recordings and files.\n",
+    "This example showcases how to deploy NVIDIA Parakeet for Automatic Speech Recognition (ASR) from the Hugging Face Collection in Azure AI Foundry Hub as an Azure ML Managed Online Endpoint, powered by Hugging Face's Inference container on top of NVIDIA NeMo. It also covers how to run inference with cURL, requests, OpenAI Python SDK, and even how to locally run a Gradio application for audio transcription from both recordings and files.\n",
     "\n",
     "TL;DR NVIDIA NeMo is a scalable generative AI framework built for researchers and developers working on Large Language Models, Multimodal, and Speech AI (Automatic Speech Recognition and Text-to-Speech). NVIDIA NeMo Parakeet ASR Models attain strong speech recognition accuracy while being efficient for inference. Azure AI Foundry provides a unified platform for enterprise AI operations, model builders, and application development. Azure Machine Learning is a cloud service for accelerating and managing the machine learning (ML) project lifecycle."
    ]
@@ -152,7 +152,7 @@
    "id": "b27c159f-93b9-4ba0-b6ed-9eb4a07729b7",
    "metadata": {},
    "source": [
-    "An Azure Resource Group under the one you will create the Azure AI Foundry Hub-based project (note it will create an Azure AI Foundry resource as an Azure ML Workspace, but not the other way around, meaning that the Azure AI Foundry Hub will be listed as an Azure ML workspace, but leveraging the Azure AI Foundry capabilities for Gen AI), and the rest of the required resources. If you don't have one, you can create it as follow:\n",
+    "An Azure Resource Group under the one you will create the Azure AI Foundry Hub-based project (note it will create an Azure AI Foundry resource as an Azure ML Workspace, but not the other way around, meaning that the Azure AI Foundry Hub will be listed as an Azure ML workspace, but leveraging the Azure AI Foundry capabilities for Gen AI), and the rest of the required resources. If you don't have one, you can create it as follows:\n",
     "\n",
     "```bash\n",
     "az group create --name huggingface-azure-rg --location eastus\n",
@@ -183,7 +183,7 @@
    "id": "d0b2c56d-9197-42e0-b723-63811c7e25f0",
    "metadata": {},
    "source": [
-    "An Azure AI Foundry Hub under the subscription and resource group aforementioned. If you don't have one, you can create it as follows:\n",
+    "An Azure AI Foundry Hub under the aforementioned subscription and resource group. If you don't have one, you can create it as follows:\n",
     "\n",
     "```bash\n",
     "az ml workspace create \\\n",
@@ -301,7 +301,7 @@
     "Finally, you also need to define both the endpoint and deployment names, as those will be used throughout the example too:\n",
     "\n",
     "> [!NOTE]\n",
-    "> Note that endpoint names must to be globally unique per region i.e., even if you don't have any endpoint named that way running under your subscription, if the name is reserved by another Azure customer, then you won't be able to use the same name. Adding a timestamp or a custom identifier is recommended to prevent running into HTTP 400 validation issues when trying to deploy an endpoint with an already locked / reserved name. Also the endpoint name must be between 3 and 32 characters long."
+    "> Note that endpoint names must be globally unique per region i.e., even if you don't have any endpoint named that way running under your subscription, if the name is reserved by another Azure customer, then you won't be able to use the same name. Adding a timestamp or a custom identifier is recommended to prevent running into HTTP 400 validation issues when trying to deploy an endpoint with an already locked / reserved name. Also the endpoint name must be between 3 and 32 characters long."
    ]
   },
   {


### PR DESCRIPTION
## Description

This PR adds an example on how to serve an Automatic Speech Recognition (ASR) model from the Hugging Face collection on Azure AI / Azure ML, in this case, a speech-to-text English model from the [NVIDIA Parakeet collection on the Hub](https://huggingface.co/collections/nvidia/parakeet-659711f49d1469e51546e021) i.e., [`nvidia/parakeet-tdt-0.6b-v2`](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2).

The container powering the inference of the NVIDIA Parakeet models is [`hfendpoints`](https://github.com/huggingface/hfendpoints) running the NVIDIA NeMo inference engine underneath.

> [!WARNING]
> Note that the NVIDIA Parakeet models differ on the backend engine powering the inference from the rest of the Automatic Speech Recognition (ASR) models on the Hugging Face collection on Azure, since those are instead powered by the https://github.com/huggingface/huggingface-inference-toolkit instead, so those don't come with the OpenAI-compatible layer, and then the current example can only be extended to any other NVIDIA Parakeet model at the moment.