### PR TITLE
Fix a typo on "Azure ML Workspace"

### DIFF
--- a/examples/azure-ai/build-agents-with-smolagents/azure-notebook.ipynb
+++ b/examples/azure-ai/build-agents-with-smolagents/azure-notebook.ipynb
@@ -153,7 +153,7 @@
    "id": "c569c5f7-c95a-4497-8145-d4d7031cfb8e",
    "metadata": {},
    "source": [
-    "An Azure Resource Group under the one you will create the Azure AI Foundry Hub-based project (note it will create an Azure AI Foundry resource as an Azure L Workspace, but not the other way around, meaning that the Azure AI Foundry Hub will be listed as an Azure ML workspace, but leveraging the Azure AI Foundry capabilities for Gen AI), and the rest of the required resources. If you don't have one, you can create it as follow:\n",
+    "An Azure Resource Group under the one you will create the Azure AI Foundry Hub-based project (note it will create an Azure AI Foundry resource as an Azure ML Workspace, but not the other way around, meaning that the Azure AI Foundry Hub will be listed as an Azure ML workspace, but leveraging the Azure AI Foundry capabilities for Gen AI), and the rest of the required resources. If you don't have one, you can create it as follow:\n",
     "\n",
     "```bash\n",
     "az group create --name huggingface-azure-rg --location eastus\n",

--- a/examples/azure-ai/deploy-large-language-models/azure-notebook.ipynb
+++ b/examples/azure-ai/deploy-large-language-models/azure-notebook.ipynb
@@ -154,7 +154,7 @@
    "id": "f57e94a0-b247-44bc-a78d-7ceadb1deb85",
    "metadata": {},
    "source": [
-    "An Azure Resource Group under the one you will create the Azure AI Foundry Hub-based project (note it will create an Azure AI Foundry resource as an Azure L Workspace, but not the other way around, meaning that the Azure AI Foundry Hub will be listed as an Azure ML workspace, but leveraging the Azure AI Foundry capabilities for Gen AI), and the rest of the required resources. If you don't have one, you can create it as follow:\n",
+    "An Azure Resource Group under the one you will create the Azure AI Foundry Hub-based project (note it will create an Azure AI Foundry resource as an Azure ML Workspace, but not the other way around, meaning that the Azure AI Foundry Hub will be listed as an Azure ML workspace, but leveraging the Azure AI Foundry capabilities for Gen AI), and the rest of the required resources. If you don't have one, you can create it as follow:\n",
     "\n",
     "```bash\n",
     "az group create --name huggingface-azure-rg --location eastus\n",

--- a/examples/azure-ai/deploy-vision-language-models/azure-notebook.ipynb
+++ b/examples/azure-ai/deploy-vision-language-models/azure-notebook.ipynb
@@ -155,7 +155,7 @@
    "id": "b27c159f-93b9-4ba0-b6ed-9eb4a07729b7",
    "metadata": {},
    "source": [
-    "An Azure Resource Group under the one you will create the Azure AI Foundry Hub-based project (note it will create an Azure AI Foundry resource as an Azure L Workspace, but not the other way around, meaning that the Azure AI Foundry Hub will be listed as an Azure ML workspace, but leveraging the Azure AI Foundry capabilities for Gen AI), and the rest of the required resources. If you don't have one, you can create it as follow:\n",
+    "An Azure Resource Group under the one you will create the Azure AI Foundry Hub-based project (note it will create an Azure AI Foundry resource as an Azure ML Workspace, but not the other way around, meaning that the Azure AI Foundry Hub will be listed as an Azure ML workspace, but leveraging the Azure AI Foundry capabilities for Gen AI), and the rest of the required resources. If you don't have one, you can create it as follow:\n",
     "\n",
     "```bash\n",
     "az group create --name huggingface-azure-rg --location eastus\n",


### PR DESCRIPTION
## Description

This PR fixes a typo on "Azure ML Workspace", written as "Azure L Workspace" instead.