### PR TITLE
Update SmolLM3 version, add outputs and remove `azure-ai-inference` warn

### DIFF
--- a/examples/azure-ai/deploy-smollm3/azure-notebook.ipynb
+++ b/examples/azure-ai/deploy-smollm3/azure-notebook.ipynb
@@ -342,10 +342,7 @@
     "Finally, now that the Azure AI Endpoint is deployed, you can send requests to it. In this case, since the task of the model is `text-generation` (also known as `chat-completion`) you can use the OpenAI SDK with the OpenAI-compatible route and send requests to the scoring URI i.e., `/v1/chat/completions`.\n",
     "\n",
     "> [!NOTE]\n",
-    "> Note that below only some of the options are listed, but you can send requests to the deployed endpoint as long as you send the HTTP requests with the `azureml-model-deployment` header set to the name of the Azure AI Deployment (not the Endpoint), and have the necessary authentication token / key to send requests to the given endpoint; then you can send HTTP request to all the routes that the backend engine is exposing, not only to the scoring route.\n",
-    "\n",
-    "> [!WARNING]\n",
-    "> Support for Hugging Face models via [`azure-ai-inference` Python SDK](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/ai/azure-ai-inference) is still a work in progress, but that will be included soon and set as the recommended inference method, stay tuned!"
+    "> Note that below only some of the options are listed, but you can send requests to the deployed endpoint as long as you send the HTTP requests with the `azureml-model-deployment` header set to the name of the Azure AI Deployment (not the Endpoint), and have the necessary authentication token / key to send requests to the given endpoint; then you can send HTTP request to all the routes that the backend engine is exposing, not only to the scoring route."
    ]
   },
   {

--- a/examples/azure-ai/deploy-smollm3/azure-notebook.ipynb
+++ b/examples/azure-ai/deploy-smollm3/azure-notebook.ipynb
@@ -33,7 +33,7 @@
    "id": "a21e077e",
    "metadata": {},
    "source": [
-    "This example will specifically deploy [`HuggingFaceTB/SmolLM3-3B`](https://huggingface.co/HuggingFaceTB/SmolLM3-3B) from the Hugging Face Hub (or see it on [AzureML](https://ml.azure.com/models/huggingfacetb-smollm3-3b/version/1/catalog/registry/HuggingFace) or on [Azure AI Foundry](https://ai.azure.com/explore/models/huggingfacetb-smollm3-3b/version/1/registry/HuggingFace)) as an Azure ML Managed Online Endpoint on Azure AI Foundry Hub.\n",
+    "This example will specifically deploy [`HuggingFaceTB/SmolLM3-3B`](https://huggingface.co/HuggingFaceTB/SmolLM3-3B) from the Hugging Face Hub (or see it on [AzureML](https://ml.azure.com/models/huggingfacetb-smollm3-3b/version/3/catalog/registry/HuggingFace) or on [Azure AI Foundry](https://ai.azure.com/explore/models/huggingfacetb-smollm3-3b/version/3/registry/HuggingFace)) as an Azure ML Managed Online Endpoint on Azure AI Foundry Hub.\n",
     "\n",
     "SmolLM3 is a 3B parameter language model designed to push the boundaries of small models. It supports dual mode reasoning, 6 languages and long context. SmolLM3 is a fully open model that offers strong performance at the 3B–4B scale.\n",
     "\n",
@@ -453,7 +453,8 @@
     "    ],\n",
     "    max_tokens=128,\n",
     ")\n",
-    "print(completion)"
+    "print(completion)\n",
+    "# ChatCompletion(id='chatcmpl-74f6852e28', choices=[Choice(finish_reason='length', index=0, logprobs=None, message=ChatCompletionMessage(content=\"<think>\\nOkay, the user wants a simple explanation of gravity. Let me start by recalling what I know. Gravity is the force that pulls objects towards each other. But how to explain that simply?\\n\\nMaybe start with a common example, like how you fall when you jump. That's gravity pulling you down. But wait, I should mention that it's not just on Earth. The moon orbits the Earth because of gravity too. But how to make that easy to understand?\\n\\nI need to avoid technical terms. Maybe use metaphors. Like comparing gravity to a magnet, but not exactly. Or think of it as a stretchy rope pulling\", refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))], created=1753178803, model='HuggingFaceTB/SmolLM3-3B', object='chat.completion', service_tier='default', system_fingerprint='1a28be5c-df18-4e97-822f-118bf57374c8', usage=CompletionUsage(completion_tokens=128, prompt_tokens=66, total_tokens=194, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0), reasoning_tokens=0))"
    ]
   },
   {
@@ -495,7 +496,8 @@
     "    ],\n",
     "    max_tokens=128,\n",
     ")\n",
-    "print(completion)"
+    "print(completion)\n",
+    "# ChatCompletion(id='chatcmpl-776e84a272', choices=[Choice(finish_reason='length', index=0, logprobs=None, message=ChatCompletionMessage(content=\"Arr matey! Ye be askin' about gravity, the mighty force that keeps us swabbin' the decks and not floatin' off into the vast blue yonder. Gravity be the pull o' the Earth, a mighty force that keeps us grounded and keeps the stars in their place. It's like a giant invisible hand that pulls us towards the center o' the Earth, makin' sure we don't float off into space. It's what makes the apples fall from the tree and the moon orbit 'round the Earth. So, gravity be the force that keeps us all tied to this fine planet we call home.\", refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))], created=1753178805, model='HuggingFaceTB/SmolLM3-3B', object='chat.completion', service_tier='default', system_fingerprint='d644cb1c-84d6-49ae-b790-ac6011851042', usage=CompletionUsage(completion_tokens=128, prompt_tokens=72, total_tokens=200, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0), reasoning_tokens=0))"
    ]
   },
   {
@@ -529,7 +531,8 @@
     "    ],\n",
     "    max_tokens=128,\n",
     ")\n",
-    "print(completion)"
+    "print(completion)\n",
+    "# ChatCompletion(id='chatcmpl-da6188629f', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content=\"The translation of the English sentence 'The brown cat sat on the mat.' into Spanish is: 'El gato marrón se sentó en el tapete.'\\n\\nThe translation of the English sentence 'The brown cat sat on the mat.' into German is: 'Der braune Katze saß auf dem Teppich.'\", refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))], created=1753178807, model='HuggingFaceTB/SmolLM3-3B', object='chat.completion', service_tier='default', system_fingerprint='054f8a76-4e8c-4a2f-90eb-31f0e802916c', usage=CompletionUsage(completion_tokens=68, prompt_tokens=77, total_tokens=145, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0), reasoning_tokens=0))"
    ]
   },
   {
@@ -588,7 +591,8 @@
     "    tool_choice=\"auto\",\n",
     "    max_completion_tokens=256,\n",
     ")\n",
-    "print(completion)"
+    "print(completion)\n",
+    "# ChatCompletion(id='chatcmpl-c36090e6b5', choices=[Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content='<think>I need to retrieve the current weather information for New York, so I\\'ll use the get_weather function with the location set to \\'New York\\' and the unit set to \\'fahrenheit\\'.</think>\\n<tool_call>{\"name\": \"get_weather\", \"arguments\": {\"location\": \"New York\", \"unit\": \"fahrenheit\"}}</tool_call>', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call-5d5eb71a', function=Function(arguments='{\"location\": \"New York\", \"unit\": \"fahrenheit\"}', name='get_weather'), type='function')]))], created=1753178808, model='HuggingFaceTB/SmolLM3-3B', object='chat.completion', service_tier='default', system_fingerprint='5e58b305-773c-40b6-900b-fe5b177aeab9', usage=CompletionUsage(completion_tokens=68, prompt_tokens=442, total_tokens=510, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0), reasoning_tokens=0))"
    ]
   },
   {


### PR DESCRIPTION
## Description

This PR re-runs the SmolLM3 example to add the chat completion call outputs for visibility on the produced outputs, and also updates the version for the SmolLM3-3B model from the Azure AI catalog. Finally, due to the upcoming deprecation, the warning around `azure-ai-inference` support not being ready has been removed, and just default to OpenAI SDK.