### PR TITLE
Remove `azure-ai-inference` support warnings

### DIFF
--- a/examples/azure-ai/deploy-large-language-models/azure-notebook.ipynb
+++ b/examples/azure-ai/deploy-large-language-models/azure-notebook.ipynb
@@ -342,10 +342,7 @@
     "Finally, now that the Azure AI Endpoint is deployed, you can send requests to it. In this case, since the task of the model is `text-generation` (also known as `chat-completion`) you can either use the default scoring endpoint, being `/generate` which is the standard text generation endpoint without chat capabilities (as leveraging the chat template or having an OpenAI-compatible OpenAPI interface), or alternatively just benefit from the fact that the inference engine in which the model is running on top exposes OpenAI-compatible routes as `/v1/chat/completions`.\n",
     "\n",
     "> [!NOTE]\n",
-    "> Note that below only some of the options are listed, but you can send requests to the deployed endpoint as long as you send the HTTP requests with the `azureml-model-deployment` header set to the name of the Azure AI Deployment (not the Endpoint), and have the necessary authentication token / key to send requests to the given endpoint; then you can send HTTP request to all the routes that the backend engine is exposing, not only to the scoring route.\n",
-    "\n",
-    "> [!WARNING]\n",
-    "> Support for Hugging Face models via [`azure-ai-inference` Python SDK](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/ai/azure-ai-inference) is still a work in progress, but that will be included soon and set as the recommended inference method, stay tuned!"
+    "> Note that below only some of the options are listed, but you can send requests to the deployed endpoint as long as you send the HTTP requests with the `azureml-model-deployment` header set to the name of the Azure AI Deployment (not the Endpoint), and have the necessary authentication token / key to send requests to the given endpoint; then you can send HTTP request to all the routes that the backend engine is exposing, not only to the scoring route."
    ]
   },
   {

--- a/examples/azure-ai/deploy-nvidia-parakeet-asr/azure-notebook.ipynb
+++ b/examples/azure-ai/deploy-nvidia-parakeet-asr/azure-notebook.ipynb
@@ -339,10 +339,7 @@
    "source": [
     "Finally, now that the Azure AI Endpoint is deployed, you can send requests to it. In this case, since the task of the model is `automatic-speech-recognition` and since it expects a multi-part request to be sent along the audio file, the `invoke` method cannot be used since it only supports JSON payloads.\n",
     "\n",
-    "This being said, you can still send requests to it programmatically via `requests`, via the OpenAI SDK for Python or with cURL, to the `/api/v1/audio/transcriptions` route which is the OpenAI-compatible route for the Transcriptions API.\n",
-    "\n",
-    "> [!WARNING]\n",
-    "> Support for Hugging Face models via [`azure-ai-inference` Python SDK](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/ai/azure-ai-inference) is still a work in progress, but that will be included soon and set as the recommended inference method, stay tuned!"
+    "This being said, you can still send requests to it programmatically via `requests`, via the OpenAI SDK for Python or with cURL, to the `/api/v1/audio/transcriptions` route which is the OpenAI-compatible route for the Transcriptions API."
    ]
   },
   {

--- a/examples/azure-ai/deploy-vision-language-models/azure-notebook.ipynb
+++ b/examples/azure-ai/deploy-vision-language-models/azure-notebook.ipynb
@@ -343,10 +343,7 @@
     "Finally, now that the Azure AI Endpoint is deployed, you can send requests to it. In this case, since the task of the model is `image-text-to-text` (also known as `chat-completion` with image support) you can either use the default scoring endpoint, being `/generate` which is the standard text generation endpoint without chat capabilities (as leveraging the chat template or having an OpenAI-compatible OpenAPI interface), or alternatively just benefit from the fact that the inference engine in which the model is running on top exposes OpenAI-compatible routes as `/v1/chat/completions`.\n",
     "\n",
     "> [!NOTE]\n",
-    "> Note that below only some of the options are listed, but you can send requests to the deployed endpoint as long as you send the HTTP requests with the `azureml-model-deployment` header set to the name of the Azure AI Deployment (not the Endpoint), and have the necessary authentication token / key to send requests to the given endpoint; then you can send HTTP request to all the routes that the backend engine is exposing, not only to the scoring route.\n",
-    "\n",
-    "> [!WARNING]\n",
-    "> Support for Hugging Face models via [`azure-ai-inference` Python SDK](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/ai/azure-ai-inference) is still a work in progress, but that will be included soon and set as the recommended inference method, stay tuned!"
+    "> Note that below only some of the options are listed, but you can send requests to the deployed endpoint as long as you send the HTTP requests with the `azureml-model-deployment` header set to the name of the Azure AI Deployment (not the Endpoint), and have the necessary authentication token / key to send requests to the given endpoint; then you can send HTTP request to all the routes that the backend engine is exposing, not only to the scoring route."
    ]
   },
   {


### PR DESCRIPTION
## Description

This PR removes the warnings around `azure-ai-inference` compatibility coming soon, since it's going to be deprecated in favor of the OpenAI SDK, so the warning is no longer needed.

The related changes for the SmolLM3 example have already been tackled as part of #25