### PR TITLE
Update "Deploy with AzureML" refs to "Deploy on Azure AI"

### DIFF
--- a/docs/source/_redirects.yml
+++ b/docs/source/_redirects.yml
@@ -1,1 +1,2 @@
 guides/one-click-deployment-azure-ml: guides/one-click-deployment-azure-ai
+azure-ai/configure: azure-ai/set-up

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -26,6 +26,6 @@
     title: Supported Hardware
   - local: azure-ai/models
     title: Supported Models
-  - local: azure-ai/configure
-    title: Configure Microsoft Azure for Azure AI
+  - local: azure-ai/set-up
+    title: Set up Azure AI
   title: Azure AI

--- a/docs/source/azure-ai/models.mdx
+++ b/docs/source/azure-ai/models.mdx
@@ -2,22 +2,28 @@
 
 Around +11,000 open models from the Hugging Face Hub are made available on Azure AI / ML, which represents a subset out of the +1,800,000 public open-models, as the Hugging Face collection in Azure is a curated subset of the most downloaded / relevant models on the Hub, as well as compatible with Transformers, Sentence Transformers and Diffusers, as well as with other Hugging Face libraries and solutions.
 
+<Tip>
+
+Even if you don't have a Microsoft Azure account, you can still explore the [public Hugging Face Collection on Azure AI](https://ai.azure.com/catalog/publishers/hugging%20face,huggingface).
+
+</Tip>
+
 This being said, the supported models range different architectures and backends, but a way to identify whether a model from the Hugging Face Hub is made available within the model catalog in Azure AI / ML is to either:
 
-1. Navigate to the model card of the given model under https://huggingface.co/models, and make sure that the "Deploy" button is made available and that the Azure ML option is listed there. If that's the case, then if the model is available on Azure ML, the URI pointing to the model on Azure ML will be displayed, otherwise, it will not and a button for "Request to add" will show to request the model addition (more information on the latter in [Request a model addition in the Hugging Face collection on Azure](../guides/request-model-addition)).
+1. Navigate to the model card of the given model under https://huggingface.co/models, and make sure that the "Deploy" button is made available and that the "Deploy on Azure AI" option is listed there. If that's the case, then if the model is available on Azure AI, the URL pointing to the model on Azure AI will be provided via the "Go to model on Azure AI" button, otherwise, the button "Request to add" will show to request the model addition (more information on the latter in [Request a model addition in the Hugging Face collection on Azure](../guides/request-model-addition)).
 
-2. On the other hand, you can also navigate to either the Azure ML or the Azure AI Foundry (the latter only for Hub-based projects) model catalogs under the Hugging Face collection, and look for the given model on the search bar. If the model appears it means its supported and you can grab the URI pointing to it to programmatically deploy it, otherwise, you can either [open an issue](https://github.com/huggingface/Microsoft-Azure/issues/new) requesting the model addition, or request it via the Hugging Face Hub as mentioned before.
+2. On the other hand, you can also navigate to either the Azure ML or the Azure AI Foundry (the latter only for Hub-based projects) model catalogs under the Hugging Face collection, and search the given model. If the model appears, it means it's supported and you can grab the URI pointing to it to programmatically deploy it, otherwise, you can either [open an issue](https://github.com/huggingface/Microsoft-Azure/issues/new) requesting the model addition, or request it via the Hugging Face Hub model card with the "Request to add" button as mentioned before.
 
-3. Alternatively, you can also check if the given model is available programmatically with the following Python snippet, that sends a request to an Azure API that given a model ID from the Hugging Face Hub returns either HTTP 200 with the model URI if it's available, or just HTTP 404 if not available.
+3. Alternatively, you can also check if the given model is available on Azure AI programmatically with the following Python snippet, that sends a request to an Azure API that given a model ID from the Hugging Face Hub returns either HTTP 200 with the model URL if it's available, or just HTTP 404 if not available.
 
 ```python
 import requests
 
 model_id = "HuggingFaceTB/SmolLM3-3B"
-response = requests.get("https://generate-azureml-urls.azurewebsites.net/api/generate", params={"modelId": model_id})
+response = requests.get("https://get-azure-ai-url.azurewebsites.net/api/get-azure-ai-url", params={"model_id": model_id})
 if response.status_code == 200:
     print(response.json())
-    # {"url": "https://ml.azure.com/models/huggingfacetb-smollm3-3b/version/1/catalog/registry/HuggingFace"}
+    # {"url": "https://ai.azure.com/explore/models/HuggingFaceTB-SmolLM3-3B/version/3/registry/HuggingFace"}
 ```
 
-We are really excited for this partnership between Hugging Face and Microsoft Azure, and working really hard to bring Azure customers the best open models from the Hugging Face collection into Azure ML / AI, so stay tuned for updates and a lot more models to come in the following months!
+We are really excited for this partnership between Hugging Face and Microsoft Azure, and working really hard to bring Azure customers the best open models from the Hugging Face collection into Azure AI / ML, so stay tuned for updates and a lot more models to come in the following months!

--- a/docs/source/azure-ai/set-up.mdx
+++ b/docs/source/azure-ai/set-up.mdx
@@ -1,6 +1,6 @@
-# Configure Microsoft Azure for Azure AI
+# Set up Azure AI
 
-This page explains how to configure Azure AI in your Microsoft Azure subscription, required to run the Azure AI examples in this documentation, but also to run any example on Azure ML, since these are the basic pre-requisites.
+This page explains how to set up Azure AI in your Microsoft Azure subscription, required to run the Azure AI examples in this documentation, but also to run any example on Azure ML, since these are the basic pre-requisites.
 
 You can either follow along the below steps, or either read more about those in the [Azure Machine Learning Tutorial: Create resources you need to get started](https://learn.microsoft.com/en-us/azure/machine-learning/quickstart-create-resources?view=azureml-api-2).
 

--- a/docs/source/guides/request-model-addition.mdx
+++ b/docs/source/guides/request-model-addition.mdx
@@ -2,7 +2,7 @@
 
 At the moment the Hugging Face collection on Azure AI / ML contains +10,000 open models from the Hugging Face Hub, leveraging open-source inference solutions such as Text Generation Inference (TGI), vLLM, SGLang, Text Embeddings Inference (TEI), or the Hugging Face Inference Toolkit, among others to come.
 
-To request a model addition into the Hugging Face collection on the Azure AI / ML catalog (it's shared among those services), you can either navigate to the model card on the Hugging Face Hub via https://hf.co/models and then click the "Deploy" button and look for the "Deploy on Azure AI" option, that will automatically check whether a given model is already in the collection, it not available, then a "Request to add" button will appear.
+To request a model addition into the Hugging Face collection on the Azure AI / ML catalog (it's shared among those services), you can either navigate to the model card on the Hugging Face Hub via https://hf.co/models and then click the "Deploy" button and look for the "Deploy on Azure AI" option, that will automatically check whether a given model is already in the collection. If not available, then a "Request to add" button will appear.
 
 ![Request to add to Azure AI in the Hugging Face Hub](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/microsoft-azure/request-to-add.png)
 

--- a/docs/source/guides/request-model-addition.mdx
+++ b/docs/source/guides/request-model-addition.mdx
@@ -1,10 +1,10 @@
 # Request a model addition in the Hugging Face collection on Azure
 
-At the moment the Hugging Face collection on Azure ML / AI contains +10,000 open models from the Hugging Face Hub, leveraging open-source inference solutions such as Text Generation Inference (TGI), vLLM, SGLang, Text Embeddings Inference (TEI), or the Hugging Face Inference Toolkit, among others to come.
+At the moment the Hugging Face collection on Azure AI / ML contains +10,000 open models from the Hugging Face Hub, leveraging open-source inference solutions such as Text Generation Inference (TGI), vLLM, SGLang, Text Embeddings Inference (TEI), or the Hugging Face Inference Toolkit, among others to come.
 
-To request a model addition into the Hugging Face collection on the Azure ML / AI catalog (it's shared among those services), you can either navigate to the model card on the Hugging Face Hub via https://hf.co/models and then click the "Deploy" button and look for the "Deploy to Azure ML" option, that will automatically check whether a given model is already in the collection or not, and it will prompt a "Request to add".
+To request a model addition into the Hugging Face collection on the Azure AI / ML catalog (it's shared among those services), you can either navigate to the model card on the Hugging Face Hub via https://hf.co/models and then click the "Deploy" button and look for the "Deploy on Azure AI" option, that will automatically check whether a given model is already in the collection, it not available, then a "Request to add" button will appear.
 
-![Request to add to Azure ML in the Hugging Face Hub](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/microsoft-azure/request-to-add.png)
+![Request to add to Azure AI in the Hugging Face Hub](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/microsoft-azure/request-to-add.png)
 
 Alternatively, you can also [open an issue](https://github.com/huggingface/Microsoft-Azure/issues/new) with the model/s you'd like to see on the Hugging Face collection on Azure.
 
@@ -16,7 +16,7 @@ Before requesting a model addition, you need to make sure that the model or mode
 
 - If you want to benefit from the production-like inference solutions and the OpenAI-compatible interfaces for text generation and embeddings, you should also make sure that the given model has either the `text-generation-inference` (shortened as `tgi`) or `text-embeddings-inference` (shortened as `tei`) tags, respectively.
 
-- There might be some cases where the "Deploy to Azure ML" button is not enabled (shouldn't be the case, but can happen), in that case feel free to [open an issue](https://github.com/huggingface/Microsoft-Azure/issues/new) sharing the model card and we'll identify if that model can land on our catalog in Azure.
+- There might be some cases where either the "Deploy" or "Deploy on Azure AI" buttons are not enabled (shouldn't be the case, but can happen), in that case feel free to [open an issue](https://github.com/huggingface/Microsoft-Azure/issues/new) sharing the model card and we'll identify if that model can land on our catalog in Azure.
 
 - The Hugging Face Hub models MUST be public and ideally without any kind of gating restrictions, private or gated models won't be considered at the moment.
 

--- a/examples/azure-ai/build-agents-with-smolagents/azure-notebook.ipynb
+++ b/examples/azure-ai/build-agents-with-smolagents/azure-notebook.ipynb
@@ -73,7 +73,7 @@
     "- An Azure Resource Group.\n",
     "- A project based on an Azure AI Foundry Hub.\n",
     "\n",
-    "For more information, please go through the steps in [Configure Microsoft Azure for Azure AI](https://huggingface.co/docs/microsoft-azure/azure-ai/configure)."
+    "For more information, please go through the steps in [Set up Azure AI](https://huggingface.co/docs/microsoft-azure/azure-ai/set-up)."
    ]
   },
   {

--- a/examples/azure-ai/deploy-large-language-models/azure-notebook.ipynb
+++ b/examples/azure-ai/deploy-large-language-models/azure-notebook.ipynb
@@ -74,7 +74,7 @@
     "- An Azure Resource Group.\n",
     "- A project based on an Azure AI Foundry Hub.\n",
     "\n",
-    "For more information, please go through the steps in [Configure Microsoft Azure for Azure AI](https://huggingface.co/docs/microsoft-azure/azure-ai/configure)."
+    "For more information, please go through the steps in [Set up Azure AI](https://huggingface.co/docs/microsoft-azure/azure-ai/set-up)."
    ]
   },
   {

--- a/examples/azure-ai/deploy-nvidia-parakeet-asr/azure-notebook.ipynb
+++ b/examples/azure-ai/deploy-nvidia-parakeet-asr/azure-notebook.ipynb
@@ -72,7 +72,7 @@
     "- An Azure Resource Group.\n",
     "- A project based on an Azure AI Foundry Hub.\n",
     "\n",
-    "For more information, please go through the steps in [Configure Microsoft Azure for Azure AI](https://huggingface.co/docs/microsoft-azure/azure-ai/configure)."
+    "For more information, please go through the steps in [Set up Azure AI](https://huggingface.co/docs/microsoft-azure/azure-ai/set-up)."
    ]
   },
   {

--- a/examples/azure-ai/deploy-smollm3/azure-notebook.ipynb
+++ b/examples/azure-ai/deploy-smollm3/azure-notebook.ipynb
@@ -74,7 +74,7 @@
     "- An Azure Resource Group.\n",
     "- A project based on an Azure AI Foundry Hub.\n",
     "\n",
-    "For more information, please go through the steps in [Configure Microsoft Azure for Azure AI](https://huggingface.co/docs/microsoft-azure/azure-ai/configure)."
+    "For more information, please go through the steps in [Set up Azure AI](https://huggingface.co/docs/microsoft-azure/azure-ai/set-up)."
    ]
   },
   {

--- a/examples/azure-ai/deploy-vision-language-models/azure-notebook.ipynb
+++ b/examples/azure-ai/deploy-vision-language-models/azure-notebook.ipynb
@@ -75,7 +75,7 @@
     "- An Azure Resource Group.\n",
     "- A project based on an Azure AI Foundry Hub.\n",
     "\n",
-    "For more information, please go through the steps in [Configure Microsoft Azure for Azure AI](https://huggingface.co/docs/microsoft-azure/azure-ai/configure)."
+    "For more information, please go through the steps in [Set up Azure AI](https://huggingface.co/docs/microsoft-azure/azure-ai/set-up)."
    ]
   },
   {


### PR DESCRIPTION
## Description

This PR is a follow-up of #31 to update the references and screenshots still pointing to the "Deploy with AzureML" button instead of to "Deploy on Azure AI". Additionally, this PR also improves the wording a bit and adds some new content as e.g. the public Azure AI Model Catalog.

Finally, this PR also renames the section "Configure Microsoft Azure for Azure AI" to "Set-up Azure AI" instead, whilst adding the redirect in `_redirects.yml` to prevent breaking any existing link to it.