### PR TITLE
Add warning on deploying gated models from UI

### DIFF
--- a/examples/foundry/deploy-meta-sam3/azure-notebook.ipynb
+++ b/examples/foundry/deploy-meta-sam3/azure-notebook.ipynb
@@ -5,19 +5,7 @@
    "id": "aa3b3fb3-ccce-4654-8a3a-02bb4016eeaf",
    "metadata": {},
    "source": [
-    "# Deploy Meta SAM 3 on Microsoft Foundry\n",
-    "\n",
-    "<div style=\"text-align: left;\">\n",
-    "    <span style=\"display: inline-flex; align-items: center;\">\n",
-    "        <img src=\"https://az-icons.com/api/icon/ai-studio/download?format=svg\" alt=\"Microsoft Foundry Logo\" style=\"height:1em; width:auto; margin-right:0.3em;\">\n",
-    "        <a href=\"https://ai.azure.com/explore/models/facebook-sam3/version/2/registry/HuggingFace\">Meta SAM 3 on Microsoft Foundry</a>\n",
-    "    </span>\n",
-    "    •\n",
-    "    <span style=\"display: inline-flex; align-items: center;\">\n",
-    "        <img src=\"https://az-icons.com/api/icon/machine-learning/download?format=svg\" alt=\"Azure Machine Learning Logo\" style=\"height:1em; width:auto; margin-right:0.3em;\">\n",
-    "        <a href=\"https://ml.azure.com/models/facebook-sam3/version/2/catalog/registry/HuggingFace\">Meta SAM 3 on Azure Machine Learning</a>\n",
-    "    </span>\n",
-    "</div>"
+    "# Deploy Meta SAM 3 on Microsoft Foundry"
    ]
   },
   {
@@ -25,8 +13,9 @@
    "id": "8ba7ccad-be43-4cdc-9aa3-ab5acd5b5899",
    "metadata": {},
    "source": [
-    "> [!WARNING]\n",
+    "> [!NOTE]\n",
     "> At the moment gated models can only be deployed programmatically, since the Microsoft Foundry hasn't incorporated those yet; meaning that when deploying from Microsoft Foundry or Azure Machine Learning, even if the `HuggingFaceTokenConnection` is set, you might stumble upon the following error:\n",
+    "> \n",
     "> ```md\n",
     "> Failed to retrieve and inject workspace connection secrets. Please verify that the endpoint identity has been granted the Workspace Connection Secrets Reader role or any custom roles with actions Microsoft.MachineLearningServices/workspaces/connections/listsecrets/action & Microsoft.MachineLearningServices/workspaces/metadata/secrets/read and ensure that the secret reference schema in the environment variables is accurate.\n",
     "> ```"
@@ -336,9 +325,7 @@
   {
    "cell_type": "markdown",
    "id": "614189ee-a224-404a-bd5a-2347d7404c5f",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
     "## Send requests to the Foundry Endpoint"
    ]
@@ -354,9 +341,7 @@
   {
    "cell_type": "markdown",
    "id": "ca81a635-c81b-4bd8-80c4-d2b8b2680d8f",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
     "### Azure Machine Learning SDK"
    ]
@@ -383,9 +368,7 @@
     "with tempfile.NamedTemporaryFile(mode=\"w+\", delete=True, suffix=\".json\") as f:\n",
     "    json.dump({\n",
     "        \"inputs\": \"http://images.cocodataset.org/val2017/000000077595.jpg\",\n",
-    "        \"parameters\": {\n",
-    "            \"points_per_batch\":16,\n",
-    "        }\n",
+    "        \"parameters\": {\"points_per_batch\":16},\n",
     "    }, f)\n",
     "    \n",
     "    f.flush()\n",
@@ -419,9 +402,7 @@
   {
    "cell_type": "markdown",
    "id": "b8de78c8-f556-4159-a349-bcb2b124c0d6",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
     "### Python `requests`"
    ]
@@ -466,9 +447,7 @@
   {
    "cell_type": "markdown",
    "id": "6a397ef8-5e65-4ea6-9ff6-300c9de98c8a",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
     "## Print generated masks"
    ]


### PR DESCRIPTION
## Description

This PR adds a warning on the recently published SAM 3 example at #40, to warn the users that gated models cannot be deployed programmatically via neither Microsoft Foundry nor Azure Machine Learning UI, as that's not yet natively integrated within the UI, hence only programmatic deployments work for gated models at the moment.