### PR TITLE
Fix workflows by updating SHA to main

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@b0f9a6e3b6aa912656cbda9f74896eb721d29421 # main
     with:
       commit_sha: ${{ github.sha }}
       package: Microsoft-Azure

--- a/.github/workflows/doc-pr-build.yml
+++ b/.github/workflows/doc-pr-build.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@b0f9a6e3b6aa912656cbda9f74896eb721d29421 # main
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/doc-pr-upload.yml
+++ b/.github/workflows/doc-pr-upload.yml
@@ -12,7 +12,7 @@ permissions: # only because internal repo
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@9ad2de8582b56c017cb530c1165116d40433f1c6  # main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@b0f9a6e3b6aa912656cbda9f74896eb721d29421 # main
     with:
       package_name: microsoft-azure
     secrets:


### PR DESCRIPTION
## Description

Currently the CI for publishing docs is broken due to recent changes in the source workflows definitions. This PR updates the pinned SHA commit for all workflows pointing to https://github.com/huggingface/doc-builder.